### PR TITLE
Bring Maven POM up to date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,10 @@
   </repositories>
   <dependencies>
       <dependency>
-          <groupId>org.hibernate.java-persistence</groupId>
-          <artifactId>hibernate-jpa-2.0-api</artifactId>
-          <version>1.0.1.Final</version>
-          <scope>provided</scope>
-      </dependency>
+	      <groupId>org.hibernate.javax.persistence</groupId>
+	      <artifactId>hibernate-jpa-2.0-api</artifactId>
+	      <version>1.0.1.Final</version>
+	  </dependency>
       <dependency>
           <groupId>org.eclipse.persistence</groupId>
           <artifactId>eclipselink</artifactId>


### PR DESCRIPTION
The POM has an out of date repository URL for Eclipselink (and a redundant entry) as well as the JBoss repository. Additionally, there are newer/better versions of several of the packages.
