### PR TITLE
Ability to create multiple roots in non manyroot setup

### DIFF
--- a/src/main/java/org/code_factory/jpa/nestedset/JpaNestedSetManager.java
+++ b/src/main/java/org/code_factory/jpa/nestedset/JpaNestedSetManager.java
@@ -166,16 +166,16 @@ public class JpaNestedSetManager implements NestedSetManager {
      */
     @Override
     public <T extends NodeInfo> Node<T> createRoot(T root) {
-    	Configuration config = getConfig(root.getClass());
-    	
-    	int maximumRight;
-    	if (config.hasManyRoots()) {
-    		maximumRight = 0;
-    	} else {
-    		maximumRight = getMaximumRight(root.getClass());
-    	}
-    	root.setLeftValue(maximumRight + 1);
-		root.setRightValue(maximumRight + 2);
+        Configuration config = getConfig(root.getClass());
+
+        int maximumRight;
+        if (config.hasManyRoots()) {
+            maximumRight = 0;
+        } else {
+            maximumRight = getMaximumRight(root.getClass());
+        }
+        root.setLeftValue(maximumRight + 1);
+        root.setRightValue(maximumRight + 2);
         root.setLevel(0);
         em.persist(root);
         return getNode(root);


### PR DESCRIPTION
This change might not fit in with your intentions for the many roots option, so feel free to discard. What this change does is prevent the user from shooting themselves in the foot when adding more than one root to a table with no `@RootColumn`, in which case we should not create new entries with overlapping 1/2 left/right values. Instead, we add the new root to the right of the entire tree.

The desired behavior might be to throw an exception if this is attempted; however, I opted for this approach for because it is compatible with tables managed by [Awesome Nested Set](https://github.com/collectiveidea/awesome_nested_set).
