### PR TITLE
Fixed bug with the internal structure of a certain type of trees

### DIFF
--- a/src/main/java/org/code_factory/jpa/nestedset/JpaNestedSetManager.java
+++ b/src/main/java/org/code_factory/jpa/nestedset/JpaNestedSetManager.java
@@ -136,7 +136,7 @@ public class JpaNestedSetManager implements NestedSetManager {
         for (Node<T> n : treeList) {
             JpaNode<T> node = (JpaNode<T>) n;
 
-            if (node.getLevel() < level) {
+            while (node.getLevelValue() < level && stack.size() != 1) {
                 stack.pop();
             }
             level = node.getLevel();


### PR DESCRIPTION
The internal structure is invalid, in case a tree height differs for more then one level. Here is an example dump of a table, revealing the problem:

CREATE TABLE IF NOT EXISTS `Test` (
  `id` int(11) NOT NULL,
  `root_value` int(11) DEFAULT NULL,
  `level_value` int(11) DEFAULT NULL,
  `left_value` int(11) DEFAULT NULL,
  `right_value` int(11) DEFAULT NULL,
  `label` varchar(255) NOT NULL,
  `created_at` datetime NOT NULL,
  `updated_at` datetime DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `INDEX_level_value` (`level_value`),
  KEY `INDEX_right_value` (`right_value`),
  KEY `INDEX_root_value` (`root_value`),
  KEY `INDEX_left_value` (`left_value`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

INSERT INTO `Test` (`id`, `root_value`, `level_value`, `left_value`, `right_value`, `label`, `created_at`, `updated_at`) VALUES
    (1351, 1351, 0, 1, 16, 'root', '2013-10-31 09:49:10', '2013-10-31 09:49:54'),
    (1352, 1351, 1, 2, 3, 'Kategorie 1', '2013-10-31 09:49:10', NULL),
    (1353, 1351, 1, 4, 5, 'Kategorie 2', '2013-10-31 09:49:10', NULL),
    (1354, 1351, 1, 6, 11, 'Kategorie 3', '2013-10-31 09:49:10', '2013-10-31 09:49:54'),
    (1355, 1351, 1, 12, 13, 'Kategorie 4', '2013-10-31 09:49:10', '2013-10-31 09:49:54'),
    (1356, 1351, 1, 14, 15, 'Kategorie 5', '2013-10-31 09:49:10', '2013-10-31 09:49:54'),
    (1401, 1351, 2, 7, 10, 'level', '2013-10-31 09:49:42', '2013-10-31 09:49:54'),
    (1402, 1351, 3, 8, 9, 'another level', '2013-10-31 09:49:54', '2013-10-31 09:49:54');

These are pictures of the tree before and after the patch.

![unfixed](https://f.cloud.github.com/assets/817148/1444524/98a8e516-420a-11e3-8d4a-d4b04fca56ff.png)
![fixed](https://f.cloud.github.com/assets/817148/1444529/ab051964-420a-11e3-9bb8-61498deabda9.png)
