### PR TITLE
Cast fields to number via Java instead of in the query for Hibernate

### DIFF
--- a/src/main/java/org/code_factory/jpa/nestedset/JpaNestedSetManager.java
+++ b/src/main/java/org/code_factory/jpa/nestedset/JpaNestedSetManager.java
@@ -90,7 +90,7 @@ public class JpaNestedSetManager implements NestedSetManager {
         CriteriaBuilder cb = em.getCriteriaBuilder();
         CriteriaQuery<T> cq = cb.createQuery(clazz);
         Root<T> queryRoot = cq.from(clazz);
-        cq.where(cb.ge(queryRoot.get(config.getLeftFieldName()).as(Number.class), 1));
+        cq.where(cb.ge(queryRoot.<Number>get(config.getLeftFieldName()), 1));
         cq.orderBy(cb.asc(queryRoot.get(config.getLeftFieldName())));
         applyRootId(clazz, cq, rootId);
 

--- a/src/main/java/org/code_factory/jpa/nestedset/JpaNode.java
+++ b/src/main/java/org/code_factory/jpa/nestedset/JpaNode.java
@@ -213,11 +213,11 @@ class JpaNode<T extends NodeInfo> implements Node<T> {
         CriteriaBuilder cb = nsm.getEntityManager().getCriteriaBuilder();
         CriteriaQuery<T> cq = getBaseQuery();
         cq.where(cb.lt(
-                    queryRoot.get(nsm.getConfig(this.type).getLeftFieldName()).as(Number.class),
+                    queryRoot.<Number>get(nsm.getConfig(this.type).getLeftFieldName()),
                     getLeftValue()
                     ),
                 cb.gt(
-                    queryRoot.get(nsm.getConfig(this.type).getRightFieldName()).as(Number.class),
+                    queryRoot.<Number>get(nsm.getConfig(this.type).getRightFieldName()),
                     getRightValue()
                     ));
         cq.orderBy(cb.asc(queryRoot.get(nsm.getConfig(this.type).getRightFieldName())));
@@ -250,11 +250,11 @@ class JpaNode<T extends NodeInfo> implements Node<T> {
         CriteriaQuery<T> cq = getBaseQuery();
         Predicate wherePredicate = cb.and(
                 cb.gt(
-                    queryRoot.get(nsm.getConfig(this.type).getLeftFieldName()).as(Number.class),
+                    queryRoot.<Number>get(nsm.getConfig(this.type).getLeftFieldName()),
                     getLeftValue()
                     ),
                 cb.lt(
-                    queryRoot.get(nsm.getConfig(this.type).getRightFieldName()).as(Number.class),
+                    queryRoot.<Number>get(nsm.getConfig(this.type).getRightFieldName()),
                     getRightValue()
                     ));
 
@@ -262,7 +262,7 @@ class JpaNode<T extends NodeInfo> implements Node<T> {
             wherePredicate = cb.and(
                     wherePredicate,
                     cb.le(
-                        queryRoot.get(nsm.getConfig(this.type).getLevelFieldName()).as(Number.class),
+                        queryRoot.<Number>get(nsm.getConfig(this.type).getLevelFieldName()),
                         getLevel() + depth)
                         );
         }
@@ -569,8 +569,8 @@ class JpaNode<T extends NodeInfo> implements Node<T> {
         CriteriaBuilder cb = nsm.getEntityManager().getCriteriaBuilder();
         CriteriaQuery<T> cq = getBaseQuery();
         Predicate wherePredicate = cb.and(
-                cb.lt(queryRoot.get(nsm.getConfig(this.type).getLeftFieldName()).as(Number.class), getLeftValue()),
-                cb.gt(queryRoot.get(nsm.getConfig(this.type).getRightFieldName()).as(Number.class), getRightValue())
+                cb.lt(queryRoot.<Number>get(nsm.getConfig(this.type).getLeftFieldName()), getLeftValue()),
+                cb.gt(queryRoot.<Number>get(nsm.getConfig(this.type).getRightFieldName()), getRightValue())
                 );
 
         cq.where(wherePredicate);


### PR DESCRIPTION
This was breaking Hibernate's JPA implementation.

The tests were always passing since they use eclipselink's JPA implementation instead of Hibernate's.
Taken from the BlackLocus Edition of JPA-NestedSet. I think this fixes romanb/JPA-NestedSet#12.
